### PR TITLE
Use Python 3.9 in the release workflow, so that we can install depend…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
…encies