### PR TITLE
Remove sphinx-prompt dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@ extensions = [
     "sphinxcontrib.spelling",
     "sphinx_click.ext",
     "sphinx_inline_tabs",
-    "sphinx-prompt",
     "sphinx_substitution_extensions",
 ]
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -10,39 +10,39 @@ Install contribution dependencies
 
 Install Python dependencies in a virtual environment.
 
-.. prompt:: bash
+.. code-block:: console
 
-   pip install --editable '.[dev]'
+   $ pip install --editable '.[dev]'
 
 Spell checking requires ``enchant``.
 This can be installed on macOS, for example, with `Homebrew`_:
 
-.. prompt:: bash
+.. code-block:: console
 
-   brew install enchant
+   $ brew install enchant
 
 and on Ubuntu with ``apt``:
 
-.. prompt:: bash
+.. code-block:: console
 
-   apt-get install -y enchant
+   $ apt-get install -y enchant
 
 Install ``pre-commit`` hooks:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pre-commit install
+   $ pre-commit install
 
 Linting
 -------
 
 Run lint tools either by committing, or with:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pre-commit run --all-files --hook-stage commit --verbose
-   pre-commit run --all-files --hook-stage push --verbose
-   pre-commit run --all-files --hook-stage manual --verbose
+   $ pre-commit run --all-files --hook-stage commit --verbose
+   $ pre-commit run --all-files --hook-stage push --verbose
+   $ pre-commit run --all-files --hook-stage manual --verbose
 
 .. _Homebrew: https://brew.sh
 
@@ -51,9 +51,9 @@ Running tests
 
 Run ``pytest``:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pytest
+   $ pytest
 
 Documentation
 -------------
@@ -62,10 +62,10 @@ Documentation is built on Read the Docs.
 
 Run the following commands to build and view documentation locally:
 
-.. prompt:: bash
+.. code-block:: console
 
-   make docs
-   make open-docs
+   $ make docs
+   $ make open-docs
 
 Continuous integration
 ----------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,13 +25,13 @@ Requires `Homebrew`_.
 Pre-built Linux binaries
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. prompt:: bash
+.. code-block:: console
    :substitutions:
 
-   curl --fail -L https://github.com/|github-owner|/|github-repository|/releases/download/|release|/vws -o /usr/local/bin/vws && \
-   chmod +x /usr/local/bin/vws
-   curl --fail -L https://github.com/|github-owner|/|github-repository|/releases/download/|release|/vuforia-cloud-reco -o /usr/local/bin/vuforia-cloud-reco && \
-   chmod +x /usr/local/bin/vuforia-cloud-reco
+   $ curl --fail -L https://github.com/|github-owner|/|github-repository|/releases/download/|release|/vws -o /usr/local/bin/vws && \
+   $ chmod +x /usr/local/bin/vws
+   $ curl --fail -L https://github.com/|github-owner|/|github-repository|/releases/download/|release|/vuforia-cloud-reco -o /usr/local/bin/vuforia-cloud-reco && \
+   $ chmod +x /usr/local/bin/vuforia-cloud-reco
 
 Shell completion
 ~~~~~~~~~~~~~~~~

--- a/docs/source/release-process.rst
+++ b/docs/source/release-process.rst
@@ -15,9 +15,9 @@ Perform a Release
 
 #. Perform a release:
 
-   .. prompt:: bash
+   .. code-block:: console
       :substitutions:
 
-      gh workflow run release.yml --repo |github-owner|/|github-repository|
+      $ gh workflow run release.yml --repo |github-owner|/|github-repository|
 
 .. _Install GitHub CLI: https://cli.github.com/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ optional-dependencies.dev = [
     "sphinx==7.4.7",
     "sphinx-click==6.0.0",
     "sphinx-inline-tabs==2023.4.21",
-    "sphinx-prompt==1.8",
     "sphinx-substitution-extensions==2024.2.25",
     "sphinxcontrib-spelling==8",
     "types-docker==7.1.0.20240720",


### PR DESCRIPTION
It is no longer needed for my purposes, and it is not yet supported on Sphinx 8.