### PR TITLE
chore: bump uv to 0.11.7 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 fail_fast: true
 
-.uv_version: &uv_version uv==0.9.5
+.uv_version: &uv_version uv==0.11.7
 
 # We use system Python, with required dependencies specified in pyproject.toml.
 # We therefore cannot use those dependencies in pre-commit CI.


### PR DESCRIPTION
Bumps the uv pin in `.pre-commit-config.yaml` (`.uv_version` YAML anchor) to **uv 0.11.7**, matching the current [astral-sh/uv](https://github.com/astral-sh/uv) release used for pre-commit local hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the pinned `uv` version used by pre-commit hooks, affecting developer tooling/CI hook execution but not runtime code.
> 
> **Overview**
> Updates `.pre-commit-config.yaml` to pin the `uv` dependency (via the `.uv_version` YAML anchor) from `0.9.5` to `0.11.7`, so local pre-commit hooks run against the newer `uv` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8bca881d5978b665bc31e24ff549468ad071825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->