### PR TITLE
fix: use Generator instead of Iterator for contextmanager return types

### DIFF
--- a/src/vws_cli/commands.py
+++ b/src/vws_cli/commands.py
@@ -4,7 +4,7 @@ import contextlib
 import dataclasses
 import io
 import sys
-from collections.abc import Iterator
+from collections.abc import Generator
 from pathlib import Path
 
 import click
@@ -40,7 +40,7 @@ from vws_cli.options.vws import base_vws_url_option
 
 @beartype
 @contextlib.contextmanager
-def _handle_vws_exceptions() -> Iterator[None]:
+def _handle_vws_exceptions() -> Generator[None]:
     """Show error messages and catch exceptions from ``VWS-Python``."""
     error_message = ""
 

--- a/src/vws_cli/query.py
+++ b/src/vws_cli/query.py
@@ -4,7 +4,7 @@ import contextlib
 import dataclasses
 import io
 import sys
-from collections.abc import Iterator
+from collections.abc import Generator
 from pathlib import Path
 
 import click
@@ -35,7 +35,7 @@ from vws_cli.options.timeout import (
 
 @beartype
 @contextlib.contextmanager
-def _handle_vwq_exceptions() -> Iterator[None]:
+def _handle_vwq_exceptions() -> Generator[None]:
     """Show error messages and catch exceptions from ``VWS-Python``."""
     try:
         yield

--- a/src/vws_cli/vumark.py
+++ b/src/vws_cli/vumark.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import sys
-from collections.abc import Iterator
+from collections.abc import Generator
 from enum import StrEnum, unique
 from pathlib import Path
 
@@ -51,7 +51,7 @@ _FORMAT_CHOICE_TO_ACCEPT: dict[VuMarkFormatChoice, VuMarkAccept] = {
 
 @beartype
 @contextlib.contextmanager
-def _handle_vumark_exceptions() -> Iterator[None]:
+def _handle_vumark_exceptions() -> Generator[None]:
     """Show error messages and catch exceptions from ``VWS-Python``."""
     error_message = ""
 


### PR DESCRIPTION
## Summary
- Pyright 1.1.409 (being bumped in #2161) flags `@contextmanager` functions annotated with `Iterator[...]` return types as deprecated. Switch them to `Generator[...]` in `commands.py`, `query.py`, and `vumark.py`.

## Test plan
- [x] `pyright` passes locally on the three changed files
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-hint-only change across three CLI modules; no runtime behavior should change beyond static type checking.
> 
> **Overview**
> Adjusts the three CLI exception-handling context managers (in `commands.py`, `query.py`, and `vumark.py`) to return `Generator[None]` and updates imports accordingly, addressing Pyright’s deprecation warning for `Iterator[...]` with `@contextlib.contextmanager`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4d6fa0f4ac742450d800c340036edb24fadb45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->